### PR TITLE
replace links to old API doc with links to website build API doc.

### DIFF
--- a/reference.rst
+++ b/reference.rst
@@ -6,16 +6,16 @@ Reference
 Documentation about the technical aspects of OpenCMISS software and libraries.
 
 ------------------
-OpenCMISS-Zinc API Reference
+OpenCMISS-Zinc C++ API Reference
 ------------------
 
-OpenCMISS-Zinc Library `Application Programming Interface <apidoc/zinc/latest/index.html>`_ Reference.
+OpenCMISS-Zinc Library `C++ Application Programming Interface <apidoc/zinc/latest/index.html>`_ Reference.
 
 ------------------
-OpenCMISS-Iron API Reference
+OpenCMISS-Iron Fortran API Reference
 ------------------
 
-User documentation of the OpenCMISS-Iron library `Application Programming Interface <apidoc/iron/latest/fortran/index.html>`_ Reference.
+User documentation of the OpenCMISS-Iron library `Fortran Application Programming Interface <apidoc/iron/latest/fortran/index.html>`_ Reference.
 
 ------------------
 OpenCMISS-Iron Python Bindings API Reference

--- a/reference.rst
+++ b/reference.rst
@@ -6,34 +6,34 @@ Reference
 Documentation about the technical aspects of OpenCMISS software and libraries.
 
 ------------------
-Zinc API Reference
+OpenCMISS-Zinc API Reference
 ------------------
 
 OpenCMISS-Zinc Library `Application Programming Interface <apidoc/zinc/latest/index.html>`_ Reference.
 
 ------------------
-Iron API Reference
+OpenCMISS-Iron API Reference
 ------------------
 
-User documentation of the Iron library `Application Programming Interface <apidoc/iron/latest/fortran/index.html>`_ Reference.
+User documentation of the OpenCMISS-Iron library `Application Programming Interface <apidoc/iron/latest/fortran/index.html>`_ Reference.
 
 ------------------
-Iron Python Bindings API Reference
+OpenCMISS-Iron Python Bindings API Reference
 ------------------
 
-User documentation of the Iron library `Python bindings interface <apidoc/iron/latest/python/index.html>`_ Reference.
+User documentation of the OpenCMISS-Iron library `Python bindings interface <apidoc/iron/latest/python/index.html>`_ Reference.
 
 ------------------
-Iron Internal API Reference
+OpenCMISS-Iron Internal API Reference
 ------------------
 
-`Internal Application Programming Interface documentation <apidoc/iron/latest/programmer/index.html>`_  of the Iron library for developers working on Iron.
+`Internal Application Programming Interface documentation <apidoc/iron/latest/programmer/index.html>`_  of the OpenCMISS-Iron library for developers working on Iron.
 
 ------------------
-Iron C Bindings API Reference
+OpenCMISS-Iron C Bindings API Reference
 ------------------
 
-User documentation of the Iron library `C bindings interface <apidoc/iron/latest/c/index.html>`_ Reference.
+User documentation of the OpenCMISS-Iron library `C bindings interface <apidoc/iron/latest/c/index.html>`_ Reference.
 
 ------------
 Data Formats

--- a/reference.rst
+++ b/reference.rst
@@ -15,13 +15,25 @@ OpenCMISS-Zinc Library `Application Programming Interface <apidoc/zinc/latest/in
 Iron API Reference
 ------------------
 
-User documentation of the Iron library `Application Programming Interface <http://cmiss.bioeng.auckland.ac.nz/OpenCMISS/doc/user/>`_ Reference.
+User documentation of the Iron library `Application Programming Interface <apidoc/iron/latest/fortran/index.html>`_ Reference.
 
-----------------------------------
+------------------
 Iron Python Bindings API Reference
-----------------------------------
+------------------
 
-User documentation of the `Iron Python bindings interface <http://cmiss.bioeng.auckland.ac.nz/OpenCMISS/doc/python/>`_.
+User documentation of the Iron library `Python bindings interface <apidoc/iron/latest/python/index.html>`_ Reference.
+
+------------------
+Iron Internal API Reference
+------------------
+
+`Internal Application Programming Interface documentation <apidoc/iron/latest/programmer/index.html>`_  of the Iron library for developers working on Iron.
+
+------------------
+Iron C Bindings API Reference
+------------------
+
+User documentation of the Iron library `C bindings interface <apidoc/iron/latest/c/index.html>`_ Reference.
 
 ------------
 Data Formats


### PR DESCRIPTION
As part of https://github.com/OpenCMISS/website/issues/57 and https://github.com/OpenCMISS/website/issues/55, I needed to update the links to API documentation in the API References page. The effect of the changes can be seen on http://staging.opencmiss.org/documentation/reference.html